### PR TITLE
Update Claude Code Review workflow to use claude_args parameter

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -98,7 +98,7 @@ jobs:
           # only after a reviewer approves the run. Repo-wide secrets would be
           # spendable from any future workflow/job that omits the environment gate.
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          model: claude-sonnet-4-6
+          claude_args: "--model claude-sonnet-4-6"
           prompt: |
             You are orchestrating a code review of PR #${{ inputs.pr_number }} in ${{ github.repository }}.
 


### PR DESCRIPTION
## Summary
Updates the Claude Code Review GitHub Actions workflow to pass the model specification via the `claude_args` parameter instead of the deprecated `model` parameter.

## Changes
- Changed the `claude-code-oauth` action input from `model: claude-sonnet-4-6` to `claude_args: "--model claude-sonnet-4-6"`
- This aligns with the updated action interface for specifying Claude model arguments

## Details
The Claude Code Review workflow (`.github/workflows/claude-code-review.yml`) is used by the `uniplan-be-reviewer` subagent to perform automated code reviews on pull requests. This change updates the workflow to use the correct parameter format expected by the current version of the `claude-code-oauth` action.

https://claude.ai/code/session_01B149gFPZ9AUjogmZ6aGbn8