### PR TITLE
Facade migration t1 migrate roomcategory to facade pattern

### DIFF
--- a/src/main/java/org/unilab/uniplan/roomcategory/RoomCategoryController.java
+++ b/src/main/java/org/unilab/uniplan/roomcategory/RoomCategoryController.java
@@ -15,7 +15,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import org.unilab.uniplan.roomcategory.dto.RoomCategoryDto;
 import org.unilab.uniplan.roomcategory.dto.RoomCategoryRequestDto;
 import org.unilab.uniplan.roomcategory.dto.RoomCategoryResponseDto;
 
@@ -25,39 +24,32 @@ import org.unilab.uniplan.roomcategory.dto.RoomCategoryResponseDto;
 @Tag(name = "Room-Category Assignments", description = "Manage the association of rooms with categories")
 public class RoomCategoryController {
 
-    private final RoomCategoryService roomCategoryService;
-    private final RoomCategoryMapper roomCategoryMapper;
+    private final RoomCategoryWebFacade roomCategoryWebFacade;
 
     @PostMapping("/add")
-    public ResponseEntity<RoomCategoryResponseDto> createRoomCategory(
+    public ResponseEntity<Void> createRoomCategory(
         @Valid @NotNull @RequestBody final RoomCategoryRequestDto roomCategoryRequestDto) {
 
-        RoomCategoryDto roomCategoryDto = roomCategoryService.createRoomCategory(
-            roomCategoryMapper.toInternalDto(roomCategoryRequestDto));
+        roomCategoryWebFacade.createRoomCategory(roomCategoryRequestDto);
 
-        return new ResponseEntity<>(roomCategoryMapper.toResponseDto(roomCategoryDto),
-                                    HttpStatus.CREATED);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
     @GetMapping("/getAll")
-    public List<RoomCategoryResponseDto> getAllRoomCategories() {
-        return roomCategoryMapper.toResponseDtoList(roomCategoryService.getAllRoomCategories());
+    public ResponseEntity<List<RoomCategoryResponseDto>> getAllRoomCategories() {
+        return ResponseEntity.ok(roomCategoryWebFacade.getAllRoomCategories());
     }
 
     @GetMapping("/getById")
     public ResponseEntity<RoomCategoryResponseDto> getRoomCategoryById(@RequestParam final UUID roomId,
                                                                        @RequestParam final UUID categoryId) {
-        RoomCategoryDto roomCategoryDto = roomCategoryService.getRoomCategoryById(roomId,
-                                                                                  categoryId);
-
-        return ResponseEntity.ok(roomCategoryMapper.toResponseDto(roomCategoryDto));
+        return ResponseEntity.ok(roomCategoryWebFacade.getRoomCategoryById(roomId, categoryId));
     }
-
 
     @DeleteMapping("/delete")
     public ResponseEntity<Void> deleteRoomCategory(@RequestParam final UUID roomId,
                                                    @RequestParam final UUID categoryId) {
-        roomCategoryService.deleteRoomCategory(roomId, categoryId);
+        roomCategoryWebFacade.deleteRoomCategory(roomId, categoryId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/org/unilab/uniplan/roomcategory/RoomCategoryMapper.java
+++ b/src/main/java/org/unilab/uniplan/roomcategory/RoomCategoryMapper.java
@@ -4,7 +4,7 @@ import java.util.List;
 import java.util.UUID;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
-import org.unilab.uniplan.roomcategory.dto.RoomCategoryDto;
+import org.mapstruct.MappingTarget;
 import org.unilab.uniplan.roomcategory.dto.RoomCategoryRequestDto;
 import org.unilab.uniplan.roomcategory.dto.RoomCategoryResponseDto;
 
@@ -14,19 +14,19 @@ public interface RoomCategoryMapper {
     @Mapping(target = "id", expression = "java(new RoomCategoryId(dto.roomId(), dto.categoryId()))")
     @Mapping(target = "room", ignore = true)
     @Mapping(target = "category", ignore = true)
-    RoomCategory toEntity(RoomCategoryDto dto);
+    RoomCategory toEntity(RoomCategoryRequestDto dto);
 
     @Mapping(source = "id.roomId", target = "roomId")
     @Mapping(source = "id.categoryId", target = "categoryId")
-    RoomCategoryDto toDto(RoomCategory entity);
-    
-    RoomCategoryDto toInternalDto(RoomCategoryRequestDto requestDto);
+    RoomCategoryResponseDto toResponseDto(final RoomCategory roomCategory);
 
-    RoomCategoryResponseDto toResponseDto(RoomCategoryDto roomCategoryDto);
+    List<RoomCategoryResponseDto> toResponseDtoList(List<RoomCategory> roomCategories);
 
-    List<RoomCategoryDto> toDtoList(List<RoomCategory> entities);
-
-    List<RoomCategoryResponseDto> toResponseDtoList(List<RoomCategoryDto> roomCategories);
+    @Mapping(target = "id", expression = "java(new RoomCategoryId(requestDto.roomId(), requestDto.categoryId()))")
+    @Mapping(target = "room", ignore = true)
+    @Mapping(target = "category", ignore = true)
+    void updateEntity(final RoomCategoryRequestDto requestDto,
+                      @MappingTarget final RoomCategory entity);
 
     RoomCategoryId toRoomCategoryId(UUID roomId, UUID categoryId);
 }

--- a/src/main/java/org/unilab/uniplan/roomcategory/RoomCategoryService.java
+++ b/src/main/java/org/unilab/uniplan/roomcategory/RoomCategoryService.java
@@ -1,52 +1,29 @@
 package org.unilab.uniplan.roomcategory;
 
-import static org.unilab.uniplan.utils.ErrorConstants.ROOM_CATEGORY_NOT_FOUND;
-
 import java.util.List;
-import java.util.UUID;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-import org.unilab.uniplan.exception.ResourceNotFoundException;
-import org.unilab.uniplan.roomcategory.dto.RoomCategoryDto;
 
 @Service
 @RequiredArgsConstructor
 public class RoomCategoryService {
 
     private final RoomCategoryRepository roomCategoryRepository;
-    private final RoomCategoryMapper roomCategoryMapper;
 
-    @Transactional
-    public RoomCategoryDto createRoomCategory(final RoomCategoryDto roomCategoryDto) {
-        final RoomCategory roomCategory = roomCategoryMapper.toEntity(roomCategoryDto);
-
-        return roomCategoryMapper.toDto(roomCategoryRepository.save(roomCategory));
+    public void save(final RoomCategory roomCategory) {
+        roomCategoryRepository.save(roomCategory);
     }
 
-    public List<RoomCategoryDto> getAllRoomCategories() {
-        final List<RoomCategory> roomCategories = roomCategoryRepository.findAll();
-        return roomCategoryMapper.toDtoList(roomCategories);
+    public List<RoomCategory> getAll() {
+        return roomCategoryRepository.findAll();
     }
 
-    public RoomCategoryDto getRoomCategoryById(final UUID roomId, final UUID categoryId) {
-        final RoomCategoryId id = roomCategoryMapper.toRoomCategoryId(roomId, categoryId);
-
-        return roomCategoryRepository.findById(id)
-                                     .map(roomCategoryMapper::toDto)
-                                     .orElseThrow(() -> new ResourceNotFoundException(
-                                         ROOM_CATEGORY_NOT_FOUND.getMessage(String.valueOf(id))));
+    public Optional<RoomCategory> getById(final RoomCategoryId id) {
+        return roomCategoryRepository.findById(id);
     }
 
-    @Transactional
-    public void deleteRoomCategory(final UUID roomId, final UUID categoryId) {
-        final RoomCategoryId id = roomCategoryMapper.toRoomCategoryId(roomId, categoryId);
-
-        final RoomCategory roomCategory = roomCategoryRepository.findById(id)
-                                                                .orElseThrow(() -> new ResourceNotFoundException(
-                                                                    ROOM_CATEGORY_NOT_FOUND.getMessage(
-                                                                        String.valueOf(id))));
-
+    public void delete(RoomCategory roomCategory) {
         roomCategoryRepository.delete(roomCategory);
     }
 }

--- a/src/main/java/org/unilab/uniplan/roomcategory/RoomCategoryValidator.java
+++ b/src/main/java/org/unilab/uniplan/roomcategory/RoomCategoryValidator.java
@@ -23,7 +23,7 @@ public class RoomCategoryValidator {
         validateRoomExists(requestDto.roomId());
     }
 
-    public void validateForUpdate(final UUID id, final RoomCategoryRequestDto requestDto) {
+    public void validateForUpdate(final RoomCategoryId id, final RoomCategoryRequestDto requestDto) {
         validateCategoryExists(requestDto.categoryId());
         validateRoomExists(requestDto.roomId());
     }

--- a/src/main/java/org/unilab/uniplan/roomcategory/RoomCategoryValidator.java
+++ b/src/main/java/org/unilab/uniplan/roomcategory/RoomCategoryValidator.java
@@ -1,0 +1,47 @@
+package org.unilab.uniplan.roomcategory;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.unilab.uniplan.category.CategoryRepository;
+import org.unilab.uniplan.exception.ResourceNotFoundException;
+import org.unilab.uniplan.room.RoomRepository;
+import org.unilab.uniplan.roomcategory.dto.RoomCategoryRequestDto;
+
+import java.util.UUID;
+
+import static org.unilab.uniplan.utils.ErrorConstants.CATEGORY_NOT_FOUND;
+import static org.unilab.uniplan.utils.ErrorConstants.ROOM_NOT_FOUND;
+
+@Component
+@RequiredArgsConstructor
+public class RoomCategoryValidator {
+    private final CategoryRepository categoryRepository;
+    private final RoomRepository roomRepository;
+
+    public void validateForCreate(final RoomCategoryRequestDto requestDto) {
+        validateCategoryExists(requestDto.categoryId());
+        validateRoomExists(requestDto.roomId());
+    }
+
+    public void validateForUpdate(final UUID id, final RoomCategoryRequestDto requestDto) {
+        validateCategoryExists(requestDto.categoryId());
+        validateRoomExists(requestDto.roomId());
+    }
+
+    public void validateCategoryExists(final UUID categoryId) {
+        if (!categoryRepository.existsById(categoryId)) {
+            throw new ResourceNotFoundException(
+                CATEGORY_NOT_FOUND.getMessage(String.valueOf(categoryId))
+            );
+        }
+    }
+
+    public void validateRoomExists(final UUID roomId) {
+        if (!roomRepository.existsById(roomId)) {
+            throw new ResourceNotFoundException(
+                ROOM_NOT_FOUND.getMessage(String.valueOf(roomId))
+            );
+        }
+    }
+}
+

--- a/src/main/java/org/unilab/uniplan/roomcategory/RoomCategoryWebFacade.java
+++ b/src/main/java/org/unilab/uniplan/roomcategory/RoomCategoryWebFacade.java
@@ -1,0 +1,77 @@
+package org.unilab.uniplan.roomcategory;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import org.unilab.uniplan.exception.ResourceNotFoundException;
+import org.unilab.uniplan.roomcategory.dto.RoomCategoryRequestDto;
+import org.unilab.uniplan.roomcategory.dto.RoomCategoryResponseDto;
+import java.util.List;
+import java.util.UUID;
+
+import static org.unilab.uniplan.utils.ErrorConstants.ROOM_CATEGORY_NOT_FOUND;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class RoomCategoryWebFacade {
+
+    private final RoomCategoryService roomCategoryService;
+    private final RoomCategoryMapper roomCategoryMapper;
+    private final RoomCategoryValidator roomCategoryValidator;
+
+    private RoomCategory getRoomCategoryOrThrow(final RoomCategoryId id) {
+        return roomCategoryService.getById(id)
+                             .orElseThrow(() -> new ResourceNotFoundException(ROOM_CATEGORY_NOT_FOUND.getMessage(
+                                 String.valueOf(id))));
+    }
+
+    @Transactional
+    public void createRoomCategory(final RoomCategoryRequestDto requestDto) {
+        roomCategoryValidator.validateForCreate(requestDto);
+
+        final RoomCategory roomCategory = roomCategoryMapper.toEntity(requestDto);
+        roomCategoryService.save(roomCategory);
+
+        log.info("created room category with roomId: {} and categoryId: {}",
+                 requestDto.roomId(),
+                 requestDto.categoryId());
+    }
+
+    @Transactional(readOnly = true)
+    public List<RoomCategoryResponseDto> getAllRoomCategories() {
+        return roomCategoryMapper.toResponseDtoList(roomCategoryService.getAll());
+    }
+
+    @Transactional
+    public void deleteRoomCategory(final UUID roomId, final UUID categoryId) {
+        final RoomCategoryId id = roomCategoryMapper.toRoomCategoryId(roomId, categoryId);
+        final RoomCategory roomCategory = getRoomCategoryOrThrow(id);
+
+        roomCategoryService.delete(roomCategory);
+
+        log.info("deleted room category with ID: {}", id);
+    }
+
+    @Transactional(readOnly = true)
+    public RoomCategoryResponseDto getRoomCategoryById(final UUID roomId, final UUID categoryId) {
+        final RoomCategoryId id = roomCategoryMapper.toRoomCategoryId(roomId, categoryId);
+        final RoomCategory roomCategory = getRoomCategoryOrThrow(id);
+
+        return roomCategoryMapper.toResponseDto(roomCategory);
+    }
+
+    @Transactional
+    public void updateRoomCategory(final UUID roomId, final UUID categoryId, final RoomCategoryRequestDto requestDto) {
+        final RoomCategoryId id = roomCategoryMapper.toRoomCategoryId(roomId, categoryId);
+
+        roomCategoryValidator.validateForUpdate(id, requestDto);
+
+        final RoomCategory roomCategory = getRoomCategoryOrThrow(id);
+        roomCategoryMapper.updateEntity(requestDto, roomCategory);
+        roomCategoryService.save(roomCategory);
+
+        log.info("updated room category with ID: {}", roomCategory.getId());
+    }
+}

--- a/src/main/java/org/unilab/uniplan/roomcategory/dto/RoomCategoryRequestDto.java
+++ b/src/main/java/org/unilab/uniplan/roomcategory/dto/RoomCategoryRequestDto.java
@@ -5,10 +5,10 @@ import java.util.UUID;
 
 public record RoomCategoryRequestDto(
 
-    @NotNull
+    @NotNull(message = "Room ID cannot be null")
     UUID roomId,
 
-    @NotNull
+    @NotNull(message = "Category ID cannot be null")
     UUID categoryId
 ) {
 

--- a/src/main/java/org/unilab/uniplan/roomcategory/dto/RoomCategoryResponseDto.java
+++ b/src/main/java/org/unilab/uniplan/roomcategory/dto/RoomCategoryResponseDto.java
@@ -5,10 +5,10 @@ import java.util.UUID;
 
 public record RoomCategoryResponseDto(
 
-    @NotNull
+    @NotNull(message = "Room ID cannot be null")
     UUID roomId,
 
-    @NotNull
+    @NotNull(message = "Category ID cannot be null")
     UUID categoryId
 ) {
 

--- a/src/main/java/org/unilab/uniplan/roomcategory/dto/RoomCategoryResponseDto.java
+++ b/src/main/java/org/unilab/uniplan/roomcategory/dto/RoomCategoryResponseDto.java
@@ -5,10 +5,8 @@ import java.util.UUID;
 
 public record RoomCategoryResponseDto(
 
-    @NotNull(message = "Room ID cannot be null")
     UUID roomId,
 
-    @NotNull(message = "Category ID cannot be null")
     UUID categoryId
 ) {
 

--- a/src/test/java/org/unilab/uniplan/roomcategory/RoomCategoryServiceTest.java
+++ b/src/test/java/org/unilab/uniplan/roomcategory/RoomCategoryServiceTest.java
@@ -26,98 +26,59 @@ class RoomCategoryServiceTest {
     @Mock
     private RoomCategoryRepository roomCategoryRepository;
 
-    @Mock
-    private RoomCategoryMapper roomCategoryMapper;
-
     @InjectMocks
     private RoomCategoryService roomCategoryService;
 
-    private UUID roomId;
-    private UUID categoryId;
-    private RoomCategoryDto dto;
+    private RoomCategoryId id;
     private RoomCategory entity;
 
     @BeforeEach
     void setUp() {
-        roomId = UUID.randomUUID();
-        categoryId = UUID.randomUUID();
-        dto = new RoomCategoryDto(roomId, categoryId);
+        id = new RoomCategoryId(UUID.randomUUID(), UUID.randomUUID());
         entity = new RoomCategory();
     }
 
     @Test
-    void testCreateRoomCategoryShouldSaveAndReturnDto() {
-        when(roomCategoryMapper.toEntity(dto)).thenReturn(entity);
-        when(roomCategoryRepository.save(entity)).thenReturn(entity);
-        when(roomCategoryMapper.toDto(entity)).thenReturn(dto);
+    void testSaveShouldSaveRoomCategory() {
+        roomCategoryService.save(entity);
 
-        RoomCategoryDto result = roomCategoryService.createRoomCategory(dto);
-
-        assertEquals(dto, result);
+        verify(roomCategoryRepository).save(entity);
     }
 
     @Test
-    void testGetAllRoomCategoriesShouldReturnListOfRoomCategoryDtos() {
-        List<RoomCategory> entities = List.of(entity);
-        List<RoomCategoryDto> dtos = List.of(dto);
+    void testGetAllRoomCategoriesShouldReturnListOfRoomCategory() {
+        final List<RoomCategory> entities = List.of(entity);
 
         when(roomCategoryRepository.findAll()).thenReturn(entities);
-        when(roomCategoryMapper.toDtoList(entities)).thenReturn(dtos);
 
-        List<RoomCategoryDto> result = roomCategoryService.getAllRoomCategories();
+        final List<RoomCategory> result = roomCategoryService.getAll();
 
-        assertEquals(dtos, result);
+        assertEquals(entities, result);
+        verify(roomCategoryRepository).findAll();
     }
 
     @Test
-    void testGetRoomCategoryByIdShouldReturnRoomCategoryDtoIfFound() {
-        RoomCategoryId id = new RoomCategoryId(roomId, categoryId);
-
-        when(roomCategoryMapper.toRoomCategoryId(roomId, categoryId)).thenReturn(id);
+    void testGetByIdShouldReturnRoomCategoryOptional() {
         when(roomCategoryRepository.findById(id)).thenReturn(Optional.of(entity));
-        when(roomCategoryMapper.toDto(entity)).thenReturn(dto);
 
-        RoomCategoryDto result = roomCategoryService.getRoomCategoryById(roomId,
-                                                                                   categoryId);
-        assertEquals(dto, result);
+        final Optional<RoomCategory> result = roomCategoryService.getById(id);
+        assertEquals((Optional.of(entity)), result);
     }
 
     @Test
-    void testGetRoomCategoryByIdShouldReturnEmptyOptionalIfNotFound() {
-        RoomCategoryId id = new RoomCategoryId(roomId, categoryId);
-
-        when(roomCategoryMapper.toRoomCategoryId(roomId, categoryId)).thenReturn(id);
+    void testGetIdShouldReturnEmptyOptionalIfNotFound() {
         when(roomCategoryRepository.findById(id)).thenReturn(Optional.empty());
 
-        ResourceNotFoundException exception = assertThrows(ResourceNotFoundException.class, () -> roomCategoryService.getRoomCategoryById(roomId,
-                                                                                      categoryId));
+        final Optional<RoomCategory> result = roomCategoryService.getById(id);
 
-        assertTrue(exception.getMessage().contains(String.valueOf(id)));
+        assertEquals(Optional.empty(), result);
+        verify(roomCategoryRepository).findById(id);
     }
 
     @Test
-    void testDeleteRoomCategoryShouldDeleteIfFound() {
-        RoomCategoryId id = new RoomCategoryId(roomId, categoryId);
+    void testDeleteShouldDeleteIfFound() {
+       roomCategoryService.delete(entity);
 
-        when(roomCategoryMapper.toRoomCategoryId(roomId, categoryId)).thenReturn(id);
-        when(roomCategoryRepository.findById(id)).thenReturn(Optional.of(entity));
-        doAnswer(invocation -> null).when(roomCategoryRepository).delete(entity);
-
-        assertDoesNotThrow(() -> roomCategoryService.deleteRoomCategory(roomId, categoryId));
         verify(roomCategoryRepository).delete(entity);
-    }
-
-    @Test
-    void testDeleteRoomCategoryShouldThrowIfNotFound() {
-        RoomCategoryId id = new RoomCategoryId(roomId, categoryId);
-
-        when(roomCategoryMapper.toRoomCategoryId(roomId, categoryId)).thenReturn(id);
-        when(roomCategoryRepository.findById(id)).thenReturn(Optional.empty());
-
-        ResourceNotFoundException exception = assertThrows(ResourceNotFoundException.class, () ->
-            roomCategoryService.deleteRoomCategory(roomId, categoryId));
-
-        assertTrue(exception.getMessage().contains(String.valueOf(roomId)));
-        assertTrue(exception.getMessage().contains(String.valueOf(categoryId)));
     }
 }

--- a/src/test/java/org/unilab/uniplan/roomcategory/RoomCategoryWebFacadeTest.java
+++ b/src/test/java/org/unilab/uniplan/roomcategory/RoomCategoryWebFacadeTest.java
@@ -1,0 +1,168 @@
+package org.unilab.uniplan.roomcategory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.unilab.uniplan.exception.ResourceNotFoundException;
+import org.unilab.uniplan.roomcategory.dto.RoomCategoryRequestDto;
+import org.unilab.uniplan.roomcategory.dto.RoomCategoryResponseDto;
+
+@ExtendWith(MockitoExtension.class)
+class RoomCategoryWebFacadeTest {
+
+    @Mock
+    private RoomCategoryService roomCategoryService;
+
+    @Mock
+    private RoomCategoryMapper roomCategoryMapper;
+
+    @Mock
+    private RoomCategoryValidator roomCategoryValidator;
+
+    @InjectMocks
+    private RoomCategoryWebFacade roomCategoryWebFacade;
+
+    private UUID roomId;
+    private UUID categoryId;
+    private RoomCategoryId id;
+    private RoomCategory roomCategory;
+    private RoomCategoryRequestDto requestDto;
+    private RoomCategoryResponseDto responseDto;
+
+    @BeforeEach
+    void setUp() {
+        roomId = UUID.randomUUID();
+        categoryId = UUID.randomUUID();
+        id = new RoomCategoryId(roomId, categoryId);
+        roomCategory = new RoomCategory();
+        requestDto = mock(RoomCategoryRequestDto.class);
+        responseDto = mock(RoomCategoryResponseDto.class);
+    }
+
+    @Test
+    void testCreateRoomCategoryShouldValidateMapAndSaveRoomCategory() {
+        when(roomCategoryMapper.toEntity(requestDto)).thenReturn(roomCategory);
+
+        roomCategoryWebFacade.createRoomCategory(requestDto);
+
+        final InOrder inOrder = inOrder(roomCategoryValidator, roomCategoryService);
+        inOrder.verify(roomCategoryValidator).validateForCreate(requestDto);
+        inOrder.verify(roomCategoryService).save(roomCategory);
+
+        verify(roomCategoryMapper).toEntity(requestDto);
+    }
+
+    @Test
+    void testGetAllRoomCategoriesShouldReturnResponseDtoList() {
+        final List<RoomCategory> roomCategories = List.of(roomCategory);
+        final List<RoomCategoryResponseDto> responseDtos = List.of(responseDto);
+
+        when(roomCategoryService.getAll()).thenReturn(roomCategories);
+        when(roomCategoryMapper.toResponseDtoList(roomCategories)).thenReturn(responseDtos);
+
+        final List<RoomCategoryResponseDto> result = roomCategoryWebFacade.getAllRoomCategories();
+
+        assertEquals(responseDtos, result);
+        verify(roomCategoryService).getAll();
+        verify(roomCategoryMapper).toResponseDtoList(roomCategories);
+    }
+
+    @Test
+    void testGetRoomCategoryByIdShouldReturnResponseDtoIfFound() {
+        when(roomCategoryMapper.toRoomCategoryId(roomId, categoryId)).thenReturn(id);
+        when(roomCategoryService.getById(id)).thenReturn(Optional.of(roomCategory));
+        when(roomCategoryMapper.toResponseDto(roomCategory)).thenReturn(responseDto);
+
+        final RoomCategoryResponseDto result = roomCategoryWebFacade.getRoomCategoryById(roomId, categoryId);
+
+        assertEquals(responseDto, result);
+        verify(roomCategoryMapper).toRoomCategoryId(roomId, categoryId);
+        verify(roomCategoryService).getById(id);
+        verify(roomCategoryMapper).toResponseDto(roomCategory);
+    }
+
+    @Test
+    void testGetRoomCategoryByIdShouldThrowIfNotFound() {
+        when(roomCategoryMapper.toRoomCategoryId(roomId, categoryId)).thenReturn(id);
+        when(roomCategoryService.getById(id)).thenReturn(Optional.empty());
+
+        assertThrows(ResourceNotFoundException.class,
+                     () -> roomCategoryWebFacade.getRoomCategoryById(roomId, categoryId));
+
+        verify(roomCategoryMapper).toRoomCategoryId(roomId, categoryId);
+        verify(roomCategoryService).getById(id);
+        verify(roomCategoryMapper, never()).toResponseDto(any(RoomCategory.class));
+    }
+
+    @Test
+    void testUpdateRoomCategoryShouldValidateUpdateAndSaveRoomCategoryIfFound() {
+        when(roomCategoryMapper.toRoomCategoryId(roomId, categoryId)).thenReturn(id);
+        when(roomCategoryService.getById(id)).thenReturn(Optional.of(roomCategory));
+
+        roomCategoryWebFacade.updateRoomCategory(roomId, categoryId, requestDto);
+
+        final InOrder inOrder = inOrder(roomCategoryValidator, roomCategoryService);
+        inOrder.verify(roomCategoryValidator).validateForUpdate(id, requestDto);
+        inOrder.verify(roomCategoryService).getById(id);
+        inOrder.verify(roomCategoryService).save(roomCategory);
+
+        verify(roomCategoryMapper).toRoomCategoryId(roomId, categoryId);
+        verify(roomCategoryMapper).updateEntity(requestDto, roomCategory);
+    }
+
+    @Test
+    void testUpdateRoomCategoryShouldThrowIfNotFound() {
+        when(roomCategoryMapper.toRoomCategoryId(roomId, categoryId)).thenReturn(id);
+        when(roomCategoryService.getById(id)).thenReturn(Optional.empty());
+
+        assertThrows(ResourceNotFoundException.class,
+                     () -> roomCategoryWebFacade.updateRoomCategory(roomId, categoryId, requestDto));
+
+        verify(roomCategoryMapper).toRoomCategoryId(roomId, categoryId);
+        verify(roomCategoryValidator).validateForUpdate(id, requestDto);
+        verify(roomCategoryService).getById(id);
+        verify(roomCategoryMapper, never()).updateEntity(any(RoomCategoryRequestDto.class), any(RoomCategory.class));
+        verify(roomCategoryService, never()).save(any(RoomCategory.class));
+    }
+
+    @Test
+    void testDeleteRoomCategoryShouldDeleteRoomCategoryIfFound() {
+        when(roomCategoryMapper.toRoomCategoryId(roomId, categoryId)).thenReturn(id);
+        when(roomCategoryService.getById(id)).thenReturn(Optional.of(roomCategory));
+
+        roomCategoryWebFacade.deleteRoomCategory(roomId, categoryId);
+
+        verify(roomCategoryMapper).toRoomCategoryId(roomId, categoryId);
+        verify(roomCategoryService).getById(id);
+        verify(roomCategoryService).delete(roomCategory);
+    }
+
+    @Test
+    void testDeleteRoomCategoryShouldThrowIfNotFound() {
+        when(roomCategoryMapper.toRoomCategoryId(roomId, categoryId)).thenReturn(id);
+        when(roomCategoryService.getById(id)).thenReturn(Optional.empty());
+
+        assertThrows(ResourceNotFoundException.class,
+                     () -> roomCategoryWebFacade.deleteRoomCategory(roomId, categoryId));
+
+        verify(roomCategoryMapper).toRoomCategoryId(roomId, categoryId);
+        verify(roomCategoryService).getById(id);
+        verify(roomCategoryService, never()).delete(any(RoomCategory.class));
+    }
+}


### PR DESCRIPTION
Changes:
- Added RoomCategoryWebFacade
- Added RoomCategoryValidator
- Updated RoomCategoryController to use only the facade
- Refactored RoomCategoryService to use only the repository
- Moved @Transactional from service to facade.
- Updated RoomCategoryMapper to map request/response DTOs
- Updated RoomCategoryServiceTest
- Added RoomCategoryWebFacadeTest
